### PR TITLE
fix: add graphql to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "typescript": "^2.7.2",
     "semantic-release": "^15.5.2"
   },
+  "peerDependencies": {
+    "graphql": "^0.13.1 || ^14.0.0"
+  },
   "dependencies": {
     "apollo-link": "^1.2.3",
     "cross-fetch": "2.2.2",


### PR DESCRIPTION
This package depends on `apollo-link`, which lists `graphql` as a peer dependency.
[Because of this, graphql also is a (transitive) peer dependency of `http-link-dataloader` itself and needs to be listed as such.](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0)

Otherwise users see warnings, potential errors and if they're using a package manager that actually enforces package boundaries (like Yarn 2) it can't be used to begin with unless you fix the peerDependencies manually. (that's what happened to me)